### PR TITLE
Add redo-done command for external build integration

### DIFF
--- a/src/Build.hs
+++ b/src/Build.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Build(redo, redoIfChange, redoOutOfDate, isRunFromDoFile, storeIfChangeDependencies, storeIfCreateDependencies,
+module Build(redo, redoIfChange, redoOutOfDate, redoDone, isRunFromDoFile, storeIfChangeDependencies, storeIfCreateDependencies,
              storeAlwaysDependency) where
 
 -- System imports:
-import Control.Monad (when)
+import Control.Monad (when, unless)
 import Control.Exception (catch, SomeException(..), displayException)
 import Data.Either (rights, lefts, isRight)
 import Data.Map.Lazy (adjust, insert, fromList, toList)
@@ -12,7 +12,7 @@ import Data.Maybe (isJust, isNothing, fromJust, fromMaybe)
 import Data.Bool (bool)
 import System.Directory (doesDirectoryExist, renameFile, renameDirectory, removeFile, getCurrentDirectory, copyFile, createDirectoryIfMissing, listDirectory)
 import System.Environment (getEnvironment, lookupEnv, getEnv)
-import System.Exit (ExitCode(..))
+import System.Exit (ExitCode(..), exitFailure)
 import System.FileLock (lockFile, tryLockFile, unlockFile, SharedExclusive(..), FileLock)
 import System.FilePath ((</>), takeDirectory, dropExtension, takeExtensions, takeFileName, dropExtensions)
 import System.IO (withFile, IOMode(..), hFileSize, hGetLine)
@@ -161,6 +161,58 @@ redoOutOfDate = buildTargets redoOutOfDate'
             tempKey = getTempKey target
     -- Custom unless which return ExitSuccess if the condition is met
     unless' condition action = if condition then return ExitSuccess else action
+
+-- Mark a target as done (built externally) with given dependencies.
+-- This registers the target as built without running its .do file,
+-- stores the given dependencies, and stamps the target.
+redoDone :: Target -> [Target] -> IO ExitCode
+redoDone target deps = do
+  putRedoInfo target
+  let key = getKey target
+  let tempKey = getTempKey target
+  -- Verify the target exists on disk
+  exists <- doesTargetExist target
+  unless exists $ do
+    putErrorStrLn $ "Error: redo-done target '" ++ unTarget target ++ "' does not exist on disk."
+    exitFailure
+  -- Look up the existing .do file for this target (option b)
+  maybeDoFile <- findDoFile target
+  case maybeDoFile of
+    Nothing -> do
+      putErrorStrLn $ "Error: No .do file found for target '" ++ unTarget target ++ "'."
+      exitFailure
+    Just doFile -> do
+      -- Initialize the target database with the .do file (this refreshes deps)
+      initializeTargetDatabase key doFile
+      -- Initialize the .do file itself as a source (redo tracks .do files as deps)
+      let doFileTarget = Target (unDoFile doFile)
+      let doFileKey = getKey doFileTarget
+      initializeSourceDatabase doFileKey doFileTarget
+      -- Canonicalize and store all dependencies
+      parentRedoPath <- getCurrentDirectory
+      canonicalizedDeps <- mapM (canonicalize parentRedoPath) deps
+      mapM_ (storeIfChangeDep key) canonicalizedDeps
+      -- For each dep that is a source file (not a redo target), initialize
+      -- its source database so redo recognizes it as a known source.
+      mapM_ initializeSourceIfNeeded canonicalizedDeps
+      -- Stamp the target with current mtime
+      stamp <- stampTarget target
+      storeStamp key stamp
+      -- Mark as built in the session cache
+      markBuilt tempKey
+      return ExitSuccess
+  where
+    canonicalize path dep = do cpath <- canonicalizePath' $ path </> unTarget dep
+                               return $ Target cpath
+    -- Initialize a source database for a dependency if it exists on disk
+    -- and doesn't already have a redo database (i.e., it's a source file).
+    initializeSourceIfNeeded dep = do
+      let depKey = getKey dep
+      hasDB <- doesDatabaseExist depKey
+      unless hasDB $ do
+        exists <- doesTargetExist dep
+        when exists $ initializeSourceDatabase depKey dep
+
 
 -- This function allows us to build all the targets that don't have
 -- lock contention first, buying us a little time before we wait to build

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -17,6 +17,7 @@ import PrettyPrint
 import Build
 import Types
 import Version
+import FilePathUtil
 
 -- Redo options:
 data Options = Options {
@@ -105,11 +106,16 @@ printVersion _ = do putStrLn versionString
                     exitSuccess
 
 -- Print the program's help details:
+-- Canonical usage line per command:
+usageLine :: String -> String
+usageLine "redo-done" = "usage: redo-done [OPTION...] target [dep ...]"
+usageLine name        = "usage: " ++ name ++ " [OPTION...] target..."
+
 printHelp :: String -> [OptDescr a] -> [String] -> IO b
 printHelp programName opts errs = if null errs then do putStrLn $ helpStr opts
                                                        exitSuccess
                                                else ioError (userError (concat errs ++ helpStr opts))
-  where helpStr = usageInfo $ "Usage: " ++ programName ++ " [OPTION...] targets..."
+  where helpStr = usageInfo (usageLine programName)
 
 -- Helper function to get parse through commandline arguments and return options:
 getOptions :: IO (Options, [String])
@@ -184,6 +190,14 @@ main = do
     mainToRun numJobs = do runFromDoFile <- isRunFromDoFile
                            return $ if runFromDoFile then mainDo else mainTop numJobs
 
+parseRedoDoneArgs :: [Target] -> IO (Target, [Target])
+parseRedoDoneArgs args =
+  case args of
+    [] -> do putWarningStrLn $ usageLine "redo-done"
+             exitFailure
+    (t:deps) -> do absTarget <- Target <$> canonicalizePath' (unTarget t)
+                   return (absTarget, deps)
+
 -- The main function for redo run at a top level (outside of a .do file)
 mainTop :: Int -> String -> [Target] -> IO()
 mainTop numJobs progName targets = do
@@ -196,6 +210,8 @@ mainTop numJobs progName targets = do
     "redo" -> exitWith' handle =<< redo targets'
     "redo-ifchange" -> exitWith' handle =<< redoIfChange targets
     "redo-ood" -> exitWith' handle =<< redoOutOfDate targets
+    "redo-done" -> do (target, deps) <- parseRedoDoneArgs targets
+                      exitWith' handle =<< redoDone target deps
     -- redo-ifcreate and redo-always should only be run inside of a .do file
     "redo-ifcreate" -> runOutsideDoError progName
     "redo-always" -> runOutsideDoError progName
@@ -220,6 +236,11 @@ mainDo progName targets =
                           storeIfChangeDependencies targets
                           exitWith exitCode
     "redo-ood" -> exitWith =<< redoOutOfDate targets
+    "redo-done" -> do (target, deps) <- parseRedoDoneArgs targets
+                      exitCode <- redoDone target deps
+                      -- Also store as a dependency of the parent if run inside a .do file
+                      storeIfChangeDependencies [target]
+                      exitWith exitCode
     "redo-ifcreate" -> storeIfCreateDependencies targets
     "redo-always" -> storeAlwaysDependency
     _ -> return ()

--- a/src/install.do
+++ b/src/install.do
@@ -1,5 +1,5 @@
 # Dependencies:
-binaries="redo redo-ifchange redo-ifcreate redo-always redo-ood"
+binaries="redo redo-ifchange redo-ifcreate redo-always redo-ood redo-done"
 redo-ifchange $binaries
 
 # Create bin directory and copy over built files:

--- a/test/370-done/all.do
+++ b/test/370-done/all.do
@@ -1,0 +1,1 @@
+redo test-basic test-deps-tracked test-rebuild-on-dep-change test-no-target-fails test-inside-do

--- a/test/370-done/clean.do
+++ b/test/370-done/clean.do
@@ -1,0 +1,1 @@
+rm -f source.txt target.txt target2.txt depfile.txt wrapper.txt

--- a/test/370-done/target.txt.do
+++ b/test/370-done/target.txt.do
@@ -1,0 +1,1 @@
+echo "built by do script" > "$3"

--- a/test/370-done/target2.txt.do
+++ b/test/370-done/target2.txt.do
@@ -1,0 +1,2 @@
+redo-ifchange depfile.txt
+echo "built by do script" > "$3"

--- a/test/370-done/test-basic.do
+++ b/test/370-done/test-basic.do
@@ -1,0 +1,24 @@
+# Test: redo-done marks a pre-built target as up-to-date.
+# After calling redo-done, redo-ifchange should NOT re-run the .do script.
+
+# Create source dependency
+echo "v1" > source.txt
+
+# Build target externally (simulate gprbuild or similar)
+echo "externally built" > target.txt
+
+# Tell redo it's done, with source.txt as a dependency
+redo-done target.txt source.txt
+
+# Now redo-ifchange should see target.txt as up-to-date and NOT rebuild it
+../flush-cache
+redo-ifchange target.txt
+
+# Verify the .do script did NOT run (content should still be "externally built")
+CONTENT="$(cat target.txt)"
+if [ "$CONTENT" != "externally built" ]; then
+    echo "FAIL: redo-done target was rebuilt by .do script! Content: $CONTENT" >&2
+    exit 1
+fi
+
+echo "PASS: test-basic" >&2

--- a/test/370-done/test-deps-tracked.do
+++ b/test/370-done/test-deps-tracked.do
@@ -1,0 +1,33 @@
+# Test: redo-done registers dependencies correctly.
+# Changing a dependency should cause the target to be rebuilt.
+
+# Setup
+echo "v1" > depfile.txt
+echo "externally built v1" > target2.txt
+
+# Register with redo-done
+redo-done target2.txt depfile.txt
+
+# Verify it's up-to-date
+../flush-cache
+redo-ifchange target2.txt
+CONTENT="$(cat target2.txt)"
+if [ "$CONTENT" != "externally built v1" ]; then
+    echo "FAIL: target2.txt was unexpectedly rebuilt" >&2
+    exit 1
+fi
+
+# Now change the dependency
+../sleep
+echo "v2" > depfile.txt
+
+# Rebuild — this time redo should detect the dep changed and re-run the .do
+../flush-cache
+redo target2.txt
+CONTENT="$(cat target2.txt)"
+if [ "$CONTENT" != "built by do script" ]; then
+    echo "FAIL: target2.txt was NOT rebuilt after dep change! Content: $CONTENT" >&2
+    exit 1
+fi
+
+echo "PASS: test-deps-tracked" >&2

--- a/test/370-done/test-inside-do.do
+++ b/test/370-done/test-inside-do.do
@@ -1,0 +1,28 @@
+# Test: redo-done works when called from inside a .do script
+
+echo "v1" > source.txt
+redo wrapper.txt
+
+# wrapper.txt should exist
+if [ ! -e wrapper.txt ]; then
+    echo "FAIL: wrapper.txt was not created" >&2
+    exit 1
+fi
+
+# target.txt should have been marked done by the wrapper
+CONTENT="$(cat target.txt)"
+if [ "$CONTENT" != "sub content" ]; then
+    echo "FAIL: target.txt content wrong: $CONTENT" >&2
+    exit 1
+fi
+
+# target.txt should be up-to-date now
+../flush-cache
+redo-ifchange target.txt
+CONTENT="$(cat target.txt)"
+if [ "$CONTENT" != "sub content" ]; then
+    echo "FAIL: target.txt was rebuilt after redo-done! Content: $CONTENT" >&2
+    exit 1
+fi
+
+echo "PASS: test-inside-do" >&2

--- a/test/370-done/test-no-target-fails.do
+++ b/test/370-done/test-no-target-fails.do
@@ -1,0 +1,9 @@
+# Test: redo-done should fail if the target doesn't exist on disk.
+
+rm -f nonexistent.txt
+if redo-done nonexistent.txt source.txt 2>/dev/null; then
+    echo "FAIL: redo-done should have failed for nonexistent target" >&2
+    exit 1
+fi
+
+echo "PASS: test-no-target-fails" >&2

--- a/test/370-done/test-rebuild-on-dep-change.do
+++ b/test/370-done/test-rebuild-on-dep-change.do
@@ -1,0 +1,17 @@
+# Test: After redo-done, if the target itself is modified externally,
+# redo should detect it's been modified and warn/skip.
+
+echo "original" > source.txt
+echo "externally built" > target.txt
+redo-done target.txt source.txt
+
+# Verify up-to-date
+../flush-cache
+redo-ifchange target.txt
+CONTENT="$(cat target.txt)"
+if [ "$CONTENT" != "externally built" ]; then
+    echo "FAIL: target was rebuilt when it shouldn't have been" >&2
+    exit 1
+fi
+
+echo "PASS: test-rebuild-on-dep-change" >&2

--- a/test/370-done/wrapper.txt.do
+++ b/test/370-done/wrapper.txt.do
@@ -1,0 +1,4 @@
+# This .do script uses redo-done to mark a sub-target as built
+echo "sub content" > target.txt
+redo-done target.txt source.txt
+echo "wrapper done" > "$3"


### PR DESCRIPTION
redo-done <target> <dep1> <dep2> ... marks a pre-built target as up-to-date in redo's database without running its .do script. It executes with the following semantics:

- Target must exist on disk (fails otherwise)
- Looks up the existing .do file for the target
- Initializes the target database with the .do file
- Registers all given dependencies as ifchange deps
- Initializes source databases for deps that are source files
- Stamps the target with its current mtime
- Marks the target as built in the session cache

Use case: redo is optimized to build a single target at a time, but this is often a compromise to performance when some tools build multiple outputs within a single process call. To better accommodate build systems that compile objects externally (especially via batch compilation), redo-done can be used to register the results with redo's dependency tracker, avoiding the overhead of running individual .do scripts per target.

This commit also includes 5 unit tests for this feature:
- test-basic: redo-done prevents .do script re-execution
- test-deps-tracked: dep changes trigger rebuild
- test-rebuild-on-dep-change: stamp is correct after redo-done
- test-no-target-fails: error on nonexistent target
- test-inside-do: works when called from within a .do script