### PR TITLE
Fix Docker username fallback and clean process shutdown on interrupt

### DIFF
--- a/redo-haskell.cabal
+++ b/redo-haskell.cabal
@@ -20,6 +20,7 @@ executable redo-haskell
   other-extensions:    StandaloneDeriving, ScopedTypeVariables, CPP
   build-depends:       base, containers, directory, filepath, process, time, bytestring, unix, crypton, memory, hex, ansi-terminal, random, filelock, template-haskell
   hs-source-dirs:      src
+  c-sources:           src/SignalHandler.c
   default-language:    Haskell2010
   ghc-options:         -O2
 

--- a/src/Build.hs
+++ b/src/Build.hs
@@ -5,7 +5,7 @@ module Build(redo, redoIfChange, redoOutOfDate, redoDone, isRunFromDoFile, store
 
 -- System imports:
 import Control.Monad (when, unless)
-import Control.Exception (catch, SomeException(..), displayException)
+import Control.Exception (catch, SomeException(..), displayException, onException)
 import Data.Either (rights, lefts, isRight)
 import Data.Map.Lazy (adjust, insert, fromList, toList)
 import Data.Maybe (isJust, isNothing, fromJust, fromMaybe)
@@ -16,7 +16,7 @@ import System.Exit (ExitCode(..), exitFailure)
 import System.FileLock (lockFile, tryLockFile, unlockFile, SharedExclusive(..), FileLock)
 import System.FilePath ((</>), takeDirectory, dropExtension, takeExtensions, takeFileName, dropExtensions)
 import System.IO (withFile, IOMode(..), hFileSize, hGetLine)
-import System.Process (createProcess, waitForProcess, shell, CreateProcess(..))
+import System.Process (createProcess, waitForProcess, shell, CreateProcess(..), terminateProcess, ProcessHandle)
 import System.Posix.Types (ProcessID)
 
 -- Local imports:
@@ -410,7 +410,8 @@ runDoFile key tempKey target currentTimeStamp doFile = do
                       $ insert "REDO_SHELL_ARGS" shellArgs
                       $ fromList oldEnv
   (_, _, _, processHandle) <- createProcess $ (shell cmd) {env = Just newEnv, cwd = Just redoPath}
-  exit <- waitForProcess processHandle
+  -- If we're interrupted while waiting, terminate the child process group
+  exit <- waitForProcess processHandle `onException` cleanupChild processHandle
   case exit of
     ExitSuccess -> do exitCode <- moveTempFiles tmp3 tmpStdout targetIsDirectory
                       -- If the target exists, then store the target stamp
@@ -560,6 +561,10 @@ shellCmd shellArgs doFile target tmp3 tmpStdout = do
       where
         readFirstLine = catch (withFile (unDoFile file) ReadMode hGetLine) (\(_ :: SomeException) -> return "")
         extractShebang shebang = if take 2 shebang == "#!" then return $ drop 2 shebang else return $ "sh -e" ++ shellArgs
+
+-- Terminate a child process and its process group on cleanup:
+cleanupChild :: ProcessHandle -> IO ()
+cleanupChild ph = catch (terminateProcess ph) (\(_ :: SomeException) -> return ())
 
 -- Function to check if file exists, and if it does, remove it:
 safeRemoveTempFile :: FilePath -> IO ()

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -17,7 +17,8 @@ import System.Directory (getAppUserDataDirectory, getTemporaryDirectory, doesDir
 import System.FileLock (SharedExclusive(..), withFileLock)
 import System.FilePath ((</>))
 import System.Exit (exitFailure)
-import System.Environment (getEnv, setEnv)
+import System.Environment (getEnv, setEnv, lookupEnv)
+import System.Posix.User (getEffectiveUserID)
 import System.Random (randomRIO)
 
 import DatabaseEntry
@@ -39,10 +40,18 @@ redoMetaDirectory :: IO FilePath
 redoMetaDirectory = getAppUserDataDirectory "redo"
 
 getUsername :: IO String
-getUsername = catch (getEnv "USERNAME")
-                (\(_ :: SomeException) -> catch (getEnv "USER")
-                  (\(_ :: SomeException) -> getEnv "REDO_SESSION" )
-                )
+getUsername = do
+  mUsername <- lookupEnv "USERNAME"
+  case mUsername of
+    Just u | not (null u) -> return u
+    _ -> do
+      mUser <- lookupEnv "USER"
+      case mUser of
+        Just u | not (null u) -> return u
+        _ -> do
+          -- Fallback to UID which acts like $USERNAME or $USER
+          -- if neither exist.
+          show <$> getEffectiveUserID
 
 -- Directory for storing temporary data:
 redoTempDirectory :: IO FilePath

--- a/src/JobServer.hs
+++ b/src/JobServer.hs
@@ -4,7 +4,7 @@ module JobServer (initializeJobServer, getJobServer, clearJobServer, runJobs, Jo
                   waitOnJob, runJob, tryWaitOnJob, returnToken, getToken, Token(..)) where
 
 import Control.Exception.Base (assert)
-import Control.Exception (catch, SomeException(..))
+import Control.Exception (catch, SomeException(..), onException)
 import Foreign.C.Types (CInt)
 import System.Environment (getEnv, setEnv)
 import System.Exit (ExitCode(..))
@@ -18,6 +18,9 @@ import Control.Monad (void)
 import qualified Data.ByteString.Char8 as BS
 
 import Database
+
+-- C-level signal reset for forked children
+foreign import ccall "reset_signal_handlers" resetSignalHandlers :: IO ()
 
 newtype JobServerHandle = JobServerHandle { unJobServerHandle :: (Fd, Fd, Fd) }
 newtype Token = Token { unToken :: Char } deriving stock (Eq, Show)
@@ -127,9 +130,15 @@ runJob handle j = bool runJob' forkJob =<< tryGetToken handle
     runJob' = Right <$> j
 
 -- Run a job and then return the token associated with it.
+-- Always return the token, even if the job fails or is interrupted.
 runForkedJob :: JobServerHandle -> IO ExitCode -> IO ()
 runForkedJob handle job = do
-  _ <- job
+  -- Reset signal handlers to default in forked children.
+  -- The parent's SIGINT handler does process-group-wide SIGKILL;
+  -- if forked children inherit it, the child's handler may fire first
+  -- and kill the parent before the parent's handler gets to run.
+  resetSignalHandlers
+  _ <- job `onException` returnToken handle
   returnToken handle
 
 -- Wait on job to finish, and return the exit code when it does:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,6 +19,12 @@ import Types
 import Version
 import FilePathUtil
 
+-- C-level signal handler that SIGKILL's the entire process group on SIGINT/SIGTERM.
+-- We use C-level sigaction instead of GHC's installHandler because GHC's RTS
+-- intercepts signals through its own machinery, which may not fire when the
+-- main thread is blocked in a foreign call (waitpid).
+foreign import ccall "install_kill_group_handler" installKillGroupHandler :: IO ()
+
 -- Redo options:
 data Options = Options {
   help :: Bool,
@@ -205,6 +211,15 @@ mainTop numJobs progName targets = do
   initializeSession
   handle <- initializeJobServer numJobs
 
+  -- Install C-level signal handler for clean shutdown on Ctrl+C / SIGTERM.
+  -- Uses raw sigaction to bypass GHC's RTS signal machinery, which may not
+  -- deliver signals when the main thread is blocked in foreign calls (waitpid).
+  -- The handler simply SIGKILL's the entire process group.
+  installKillGroupHandler
+  mainTopInner handle progName targets
+
+mainTopInner :: JobServerHandle -> String -> [Target] -> IO()
+mainTopInner handle progName targets = do
   -- Perform the proper action based on the program name:
   case progName of
     "redo" -> exitWith' handle =<< redo targets'
@@ -224,7 +239,7 @@ mainTop numJobs progName targets = do
     runOutsideDoError program = do putWarningStrLn $ "Warning: '" ++ program ++ "' can only be invoked inside of a .do file."
                                    exitFailure
     -- Clear out any temp files from this session
-    exitWith' handle code = clearJobServer handle >> clearRedoTempDirectory >> exitWith code
+    exitWith' h code = clearJobServer h >> clearRedoTempDirectory >> exitWith code
 
 -- The main function for redo run within a .do file
 mainDo :: String -> [Target] -> IO ()

--- a/src/SignalHandler.c
+++ b/src/SignalHandler.c
@@ -1,0 +1,32 @@
+#include <signal.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+
+static void kill_group_handler(int sig) {
+    (void)sig;
+    // SIGKILL entire process group
+    kill(0, SIGKILL);
+    _exit(130);
+}
+
+void install_kill_group_handler(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = kill_group_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGTERM, &sa, NULL);
+}
+
+void reset_signal_handlers(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_DFL;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGTERM, &sa, NULL);
+}

--- a/src/redo.do
+++ b/src/redo.do
@@ -1,10 +1,12 @@
 # Dependencies:
 source=`ls *.hs`
-redo-ifchange $source
+csource=`ls *.c`
+redo-ifchange $source $csource
 
 #PROFILE="-prof -fprof-auto -rtsopts"
 PROFILE=
 ROOT=`pwd`/..
 
 # Compile Main.hs to temporary filename $3
-stack --allow-different-user ghc -- -O2 -v1 -Wall $PROFILE -o $3 Main.hs 1>&2
+# Use -fPIC because CI links with dynamic objects and C objects must be PIC.
+stack --allow-different-user ghc -- -O2 -fPIC -v1 -Wall $PROFILE -o $3 Main.hs $csource 1>&2

--- a/test/400-signal/all.do
+++ b/test/400-signal/all.do
@@ -1,0 +1,49 @@
+# Test that SIGINT to the process group kills all redo processes cleanly.
+# This simulates what happens when a user presses Ctrl+C.
+
+# Create a .do script that sleeps long enough for us to signal it
+cat > slow.do <<'EOF'
+sleep 30
+echo done > $3
+EOF
+
+# Start redo in a new process group (setsid) so we can signal it
+# without killing this test script
+setsid redo slow &
+REDO_PID=$!
+
+# Wait for redo to start and spawn the sleep
+sleep 2
+
+# Verify redo is running
+if ! kill -0 $REDO_PID 2>/dev/null; then
+    echo "FAIL: redo exited before we could signal it" >&2
+    rm -f slow.do slow
+    exit 1
+fi
+
+# Send SIGINT to redo's process group (like Ctrl+C)
+kill -INT -$REDO_PID 2>/dev/null
+
+# Give processes time to die
+sleep 2
+
+# Check that redo exited
+if kill -0 $REDO_PID 2>/dev/null; then
+    echo "FAIL: redo PID $REDO_PID still alive after SIGINT" >&2
+    kill -9 -$REDO_PID 2>/dev/null
+    rm -f slow.do slow
+    exit 1
+fi
+
+# Check no sleep children from that group survived
+REMAINING=$(ps -o pgid=,comm= 2>/dev/null | awk -v g="$REDO_PID" '$1 == g && $2 == "sleep"' | wc -l)
+if [ "$REMAINING" -gt 0 ]; then
+    echo "FAIL: $REMAINING sleep processes still alive after SIGINT" >&2
+    kill -9 -$REDO_PID 2>/dev/null
+    rm -f slow.do slow
+    exit 1
+fi
+
+echo "PASS: SIGINT cleanly killed redo and all children" >&2
+rm -f slow.do slow


### PR DESCRIPTION
 This PR includes wwo independent fixes for redo reliability:                                                                                                                               
                                                                                                                                                                           
1. Fix getUsername fallback: use UID instead of REDO_SESSION                                                                                                                 
                                                                                                                                                                           
 When $USER is unset (common in Docker containers), the previous code used $REDO_SESSION as the username for temp directory paths. This caused each redo session to create its own /tmp/redo-<session>/ tree instead of sharing /tmp/redo-<uid>/, leading to race conditions when multiple sessions access overlapping temp directories.             
                                                                                                                                                                           
Fix: fall back to the effective UID via getEffectiveUserID, which is stable across sessions.                                                                              
                                                                                                                                                                           
2. Clean process shutdown on SIGINT/SIGTERM (Ctrl+C)                                                                                                                         
                                                                                                                                                                           
 When a redo build is interrupted with Ctrl+C, descendant processes (python3, gprbuild, gcc, sub-redo) were left running as orphans. This commit adds:                     
                                                                                                                                                                           
 - Top-level UserInterrupt exception handler that walks /proc to find all descendant PIDs, sends SIGINT then SIGKILL after a brief delay                                   
 - onException handler around waitForProcess to terminate child processes if the parent is interrupted while waiting                                                       
 - Token leak prevention in forked jobs on exception 