### PR TITLE
fix: persistent cross-session target locking

### DIFF
--- a/src/Database.hs
+++ b/src/Database.hs
@@ -82,11 +82,14 @@ redoCacheDirectory = do
   root <- redoTempDirectory
   return $ root </> "cache"
 
--- Directory for storing target file locks to syncronize parallel builds of targets
+-- Directory for storing target file locks to synchronize parallel builds of targets
+-- Uses persistent directory (~/.redo/locks/) so locks work across separate redo sessions
 redoTargetLockFileDirectory :: IO FilePath
 redoTargetLockFileDirectory = do
-  root <- redoTempDirectory
-  return $ root </> "target_locks"
+  root <- redoMetaDirectory
+  let dir = root </> "locks"
+  safeCreateDirectoryRecursive dir
+  return dir
 
 -- Directory for storing database file locks to syncronize parallel database access
 redoDatabaseLockFileDirectory :: IO FilePath


### PR DESCRIPTION
Move target lock files from session-scoped `/tmp` dir to persistent `~/.redo/locks/` so concurrent redo invocations coordinate properly.

### Problem

Each redo session creates lock files in its own `/tmp/redo-<uid>/<session>/target_locks/` subdirectory. When multiple `redo` commands run simultaneously (e.g., building different components that share dependencies), they can't see each other's locks and race on shared build targets.

### Fix

Use `~/.redo/locks/` as a shared, persistent lock directory. All redo sessions now coordinate through the same lock files, preventing concurrent builds from corrupting shared targets.