### PR TITLE
Add cross-session file locking + concurrent build tests

### DIFF
--- a/src/Database.hs
+++ b/src/Database.hs
@@ -82,17 +82,25 @@ redoCacheDirectory = do
   root <- redoTempDirectory
   return $ root </> "cache"
 
--- Directory for storing target file locks to syncronize parallel builds of targets
+-- Directory for storing target file locks to synchronize parallel builds of targets.
+-- Uses a global directory so locks work across separate redo sessions.
 redoTargetLockFileDirectory :: IO FilePath
 redoTargetLockFileDirectory = do
-  root <- redoTempDirectory
-  return $ root </> "target_locks"
+  user <- getUsername
+  base <- getTemporaryDirectory
+  let dir = base </> "redo-" ++ user ++ "-locks" </> "targets"
+  safeCreateDirectoryRecursive dir
+  return dir
 
--- Directory for storing database file locks to syncronize parallel database access
+-- Directory for storing database file locks to synchronize parallel database access.
+-- Uses a global directory so locks work across separate redo sessions.
 redoDatabaseLockFileDirectory :: IO FilePath
 redoDatabaseLockFileDirectory = do
-  root <- redoTempDirectory
-  return $ root </> "db_locks"
+  user <- getUsername
+  base <- getTemporaryDirectory
+  let dir = base </> "redo-" ++ user ++ "-locks" </> "db"
+  safeCreateDirectoryRecursive dir
+  return dir
 
 -- Directory for storing temporary target files to automically building redo files
 redoTempTargetDirectory :: IO FilePath
@@ -357,8 +365,6 @@ clearRedoTempDirectory = safeRemoveDirectoryRecursive =<< redoTempDirectory
 createRedoTempDirectory :: IO ()
 createRedoTempDirectory = do
   safeCreateDirectoryRecursive =<< redoCacheDirectory
-  safeCreateDirectoryRecursive =<< redoDatabaseLockFileDirectory
-  safeCreateDirectoryRecursive =<< redoTargetLockFileDirectory
   safeCreateDirectoryRecursive =<< redoTempTargetDirectory
   safeCreateDirectoryRecursive =<< redoStdoutTargetDirectory
 

--- a/test/410-concurrent/all.do
+++ b/test/410-concurrent/all.do
@@ -1,0 +1,142 @@
+exec >&2
+
+echo
+echo "  concurrent: same target from two processes"
+
+# Test 1: Two processes build the same target simultaneously.
+# The target takes ~1s to build. Both processes should produce correct output.
+rm -f shared
+redo shared &
+PID1=$!
+redo shared &
+PID2=$!
+FAIL=0
+wait $PID1 || FAIL=1
+wait $PID2 || FAIL=1
+if [ "$FAIL" -ne 0 ]; then
+    echo "FAIL: one or both concurrent builds of same target failed" >&2
+    exit 1
+fi
+RESULT=$(cat shared)
+if [ "$RESULT" != "shared-output" ]; then
+    echo "FAIL: shared target corrupted: got '$RESULT'" >&2
+    exit 1
+fi
+echo "  concurrent: same target OK"
+
+echo "  concurrent: overlapping dependency chains"
+
+# Test 2: Two chains that share a common deep dependency.
+# chain_a -> mid_a -> deep
+# chain_b -> mid_b -> deep
+# Build both chains concurrently. Both should get correct results.
+rm -f chain_a chain_b mid_a mid_b deep
+redo chain_a &
+PID1=$!
+redo chain_b &
+PID2=$!
+FAIL=0
+wait $PID1 || FAIL=1
+wait $PID2 || FAIL=1
+if [ "$FAIL" -ne 0 ]; then
+    echo "FAIL: one or both dependency chain builds failed" >&2
+    exit 1
+fi
+RESULT_A=$(cat chain_a)
+RESULT_B=$(cat chain_b)
+if [ "$RESULT_A" != "chain_a:mid_a:deep" ]; then
+    echo "FAIL: chain_a corrupted: got '$RESULT_A'" >&2
+    exit 1
+fi
+if [ "$RESULT_B" != "chain_b:mid_b:deep" ]; then
+    echo "FAIL: chain_b corrupted: got '$RESULT_B'" >&2
+    exit 1
+fi
+echo "  concurrent: overlapping chains OK"
+
+echo "  concurrent: stress test (4 processes, shared targets)"
+
+# Test 3: 4 processes all building the same set of targets.
+# Verify no corruption after all complete.
+rm -f stress
+redo stress &
+redo stress &
+redo stress &
+redo stress &
+FAIL=0
+wait || FAIL=1
+if [ "$FAIL" -ne 0 ]; then
+    echo "FAIL: stress test had failures" >&2
+    exit 1
+fi
+RESULT=$(cat stress)
+if [ "$RESULT" != "stress-output" ]; then
+    echo "FAIL: stress target corrupted: got '$RESULT'" >&2
+    exit 1
+fi
+echo "  concurrent: stress test OK"
+
+echo "  concurrent: simultaneous builds of different targets with shared dep"
+
+# Test 4: Multiple independent targets that all depend on one slow source.
+# Build all concurrently. Verifies the DB handles multiple writers updating
+# different targets' dep records at the same time.
+rm -f result_a result_b result_c slow_dep
+redo result_a &
+PID1=$!
+redo result_b &
+PID2=$!
+redo result_c &
+PID3=$!
+FAIL=0
+wait $PID1 || FAIL=1
+wait $PID2 || FAIL=1
+wait $PID3 || FAIL=1
+if [ "$FAIL" -ne 0 ]; then
+    echo "FAIL: multi-target concurrent build had failures" >&2
+    exit 1
+fi
+if [ "$(cat result_a)" != "a:slow_dep_val" ]; then
+    echo "FAIL: result_a wrong: got '$(cat result_a)'" >&2
+    exit 1
+fi
+if [ "$(cat result_b)" != "b:slow_dep_val" ]; then
+    echo "FAIL: result_b wrong: got '$(cat result_b)'" >&2
+    exit 1
+fi
+if [ "$(cat result_c)" != "c:slow_dep_val" ]; then
+    echo "FAIL: result_c wrong: got '$(cat result_c)'" >&2
+    exit 1
+fi
+echo "  concurrent: shared dep OK"
+
+echo "  concurrent: rapid-fire rebuild (detect stale reads)"
+
+# Test 5: Build a target, force-invalidate it by touching the .do file,
+# then launch concurrent rebuilds. Without locking, one process may read
+# the stale output while the other is mid-rebuild.
+rm -f rapid
+redo rapid
+FIRST=$(cat rapid)
+# Touch the .do file to force rebuild
+sleep 1.1
+touch rapid.do
+redo rapid &
+PID1=$!
+redo rapid &
+PID2=$!
+FAIL=0
+wait $PID1 || FAIL=1
+wait $PID2 || FAIL=1
+if [ "$FAIL" -ne 0 ]; then
+    echo "FAIL: rapid-fire rebuild had failures" >&2
+    exit 1
+fi
+RESULT=$(cat rapid)
+if [ "$RESULT" != "rapid-output" ]; then
+    echo "FAIL: rapid target corrupted: got '$RESULT'" >&2
+    exit 1
+fi
+echo "  concurrent: rapid-fire rebuild OK"
+
+echo "  concurrent: all tests passed"

--- a/test/410-concurrent/chain_a.do
+++ b/test/410-concurrent/chain_a.do
@@ -1,0 +1,2 @@
+redo-ifchange mid_a
+echo "chain_a:$(cat mid_a)" > "$3"

--- a/test/410-concurrent/chain_b.do
+++ b/test/410-concurrent/chain_b.do
@@ -1,0 +1,2 @@
+redo-ifchange mid_b
+echo "chain_b:$(cat mid_b)" > "$3"

--- a/test/410-concurrent/deep.do
+++ b/test/410-concurrent/deep.do
@@ -1,0 +1,3 @@
+# Shared deep dependency — slow to maximize race window
+sleep 1
+echo "deep" > "$3"

--- a/test/410-concurrent/mid_a.do
+++ b/test/410-concurrent/mid_a.do
@@ -1,0 +1,2 @@
+redo-ifchange deep
+echo "mid_a:$(cat deep)" > "$3"

--- a/test/410-concurrent/mid_b.do
+++ b/test/410-concurrent/mid_b.do
@@ -1,0 +1,2 @@
+redo-ifchange deep
+echo "mid_b:$(cat deep)" > "$3"

--- a/test/410-concurrent/rapid.do
+++ b/test/410-concurrent/rapid.do
@@ -1,0 +1,2 @@
+# Quick build target for rapid-fire rebuild test
+echo "rapid-output" > "$3"

--- a/test/410-concurrent/result_a.do
+++ b/test/410-concurrent/result_a.do
@@ -1,0 +1,2 @@
+redo-ifchange slow_dep
+echo "a:$(cat slow_dep)" > "$3"

--- a/test/410-concurrent/result_b.do
+++ b/test/410-concurrent/result_b.do
@@ -1,0 +1,2 @@
+redo-ifchange slow_dep
+echo "b:$(cat slow_dep)" > "$3"

--- a/test/410-concurrent/result_c.do
+++ b/test/410-concurrent/result_c.do
@@ -1,0 +1,2 @@
+redo-ifchange slow_dep
+echo "c:$(cat slow_dep)" > "$3"

--- a/test/410-concurrent/shared.do
+++ b/test/410-concurrent/shared.do
@@ -1,0 +1,3 @@
+# Slow-building target to create a race window
+sleep 1
+echo "shared-output" > "$3"

--- a/test/410-concurrent/slow_dep.do
+++ b/test/410-concurrent/slow_dep.do
@@ -1,0 +1,3 @@
+# Slow shared dependency
+sleep 0.8
+echo "slow_dep_val" > "$3"

--- a/test/410-concurrent/stress.do
+++ b/test/410-concurrent/stress.do
@@ -1,0 +1,3 @@
+# Moderate delay to create contention window
+sleep 0.5
+echo "stress-output" > "$3"


### PR DESCRIPTION
Two commits:

### 1. Cross-session file locking
Moves target and database lock files from per-session temp directories (`/tmp/redo-<user>/<session>/`) to a global location (`/tmp/redo-<uid>-locks/`).

**Before:** Each top-level `redo` invocation used its own `REDO_SESSION`-scoped lock directory. Two separate `redo` commands could not coordinate locks on shared targets — they'd both build the same target simultaneously.

**After:** Lock files are UID-namespaced in `/tmp` (auto-cleanup on reboot) and shared across all redo sessions for the same user. The `flock()` mechanism is unchanged — only the directory location moves.

### 2. Concurrent build tests (`test/410-concurrent/`)
5 tests exercising cross-session concurrency:
1. Same target from two processes simultaneously
2. Overlapping dependency chains with shared deep dep
3. Stress test: 4 processes building same target
4. Different targets with shared slow dependency
5. Rapid-fire rebuild after .do file invalidation

### Why

The existing locking only worked for intra-session parallelism (`-j` flag). When two separate `redo` processes built overlapping targets, they couldn't see each other's locks. This is a real scenario in CI pipelines, multi-terminal development, and script-driven builds.