### PR TITLE
Fix redo-done no-op rebuild correctness and performance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Haskell Stack
         uses: haskell-actions/setup@v2
@@ -22,7 +22,7 @@ jobs:
           stack-version: 'latest'
 
       - name: Cache Stack dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.stack
@@ -48,7 +48,7 @@ jobs:
           redo test/all
 
       - name: Archive redo binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: redo_bin
           path: ${{ github.workspace }}/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Haskell Stack
         uses: haskell-actions/setup@v2
@@ -90,7 +90,7 @@ jobs:
           sha256sum redo-${{ matrix.platform }}.tar.gz > redo-${{ matrix.platform }}.tar.gz.sha256
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: redo-${{ matrix.platform }}
           path: |
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 

--- a/src/Build.hs
+++ b/src/Build.hs
@@ -188,11 +188,15 @@ redoDone target deps = do
       cachedStamp <- getStamp key
       cachedDoFile <- getDoFile key
       if currentStamp == cachedStamp && cachedDoFile == Just doFile then do
-        -- Target hasn't changed since last build — just mark built in session cache
-        markBuilt tempKey
+        -- Target hasn't changed since last build — mark clean (not "built")
+        -- so parents don't unnecessarily rebuild. At level > 0, "built" means
+        -- "newly built" which triggers parent rebuilds even if nothing changed.
+        markClean tempKey
         return ExitSuccess
       else do
         putRedoInfo target
+        -- Get the old stamp before refreshing, so we can detect if the target changed
+        oldStamp <- getStamp key
         -- Initialize the target database with the .do file (this refreshes deps)
         initializeTargetDatabase key doFile
         -- Initialize the .do file itself as a source (redo tracks .do files as deps)
@@ -209,8 +213,13 @@ redoDone target deps = do
         -- Stamp the target with current mtime
         stamp <- stampTarget target
         storeStamp key stamp
-        -- Mark as built in the session cache
-        markBuilt tempKey
+        -- If the stamp hasn't changed, mark as clean (verified up-to-date).
+        -- If the stamp changed, mark as built (actually rebuilt, parents need updating).
+        -- Using markBuilt unconditionally would cause parents to rebuild even when
+        -- the target didn't change, because at level > 0 "built" means "newly built".
+        if Just stamp == oldStamp
+          then markClean tempKey
+          else markBuilt tempKey
         return ExitSuccess
   where
     canonicalize path dep = do cpath <- canonicalizePath' $ path </> unTarget dep

--- a/src/Build.hs
+++ b/src/Build.hs
@@ -167,7 +167,6 @@ redoOutOfDate = buildTargets redoOutOfDate'
 -- stores the given dependencies, and stamps the target.
 redoDone :: Target -> [Target] -> IO ExitCode
 redoDone target deps = do
-  putRedoInfo target
   let key = getKey target
   let tempKey = getTempKey target
   -- Verify the target exists on disk
@@ -175,32 +174,44 @@ redoDone target deps = do
   unless exists $ do
     putErrorStrLn $ "Error: redo-done target '" ++ unTarget target ++ "' does not exist on disk."
     exitFailure
-  -- Look up the existing .do file for this target (option b)
+  -- Look up the existing .do file for this target
   maybeDoFile <- findDoFile target
   case maybeDoFile of
     Nothing -> do
       putErrorStrLn $ "Error: No .do file found for target '" ++ unTarget target ++ "'."
       exitFailure
     Just doFile -> do
-      -- Initialize the target database with the .do file (this refreshes deps)
-      initializeTargetDatabase key doFile
-      -- Initialize the .do file itself as a source (redo tracks .do files as deps)
-      let doFileTarget = Target (unDoFile doFile)
-      let doFileKey = getKey doFileTarget
-      initializeSourceDatabase doFileKey doFileTarget
-      -- Canonicalize and store all dependencies
-      parentRedoPath <- getCurrentDirectory
-      canonicalizedDeps <- mapM (canonicalize parentRedoPath) deps
-      mapM_ (storeIfChangeDep key) canonicalizedDeps
-      -- For each dep that is a source file (not a redo target), initialize
-      -- its source database so redo recognizes it as a known source.
-      mapM_ initializeSourceIfNeeded canonicalizedDeps
-      -- Stamp the target with current mtime
-      stamp <- stampTarget target
-      storeStamp key stamp
-      -- Mark as built in the session cache
-      markBuilt tempKey
-      return ExitSuccess
+      -- Early exit: if target stamp is unchanged and DB already exists with
+      -- the same dofile, skip the expensive DB refresh. This makes no-op
+      -- rebuilds fast when redo-done is called for many targets.
+      currentStamp <- safeStampTarget target
+      cachedStamp <- getStamp key
+      cachedDoFile <- getDoFile key
+      if currentStamp == cachedStamp && cachedDoFile == Just doFile then do
+        -- Target hasn't changed since last build — just mark built in session cache
+        markBuilt tempKey
+        return ExitSuccess
+      else do
+        putRedoInfo target
+        -- Initialize the target database with the .do file (this refreshes deps)
+        initializeTargetDatabase key doFile
+        -- Initialize the .do file itself as a source (redo tracks .do files as deps)
+        let doFileTarget = Target (unDoFile doFile)
+        let doFileKey = getKey doFileTarget
+        initializeSourceDatabase doFileKey doFileTarget
+        -- Canonicalize and store all dependencies
+        parentRedoPath <- getCurrentDirectory
+        canonicalizedDeps <- mapM (canonicalize parentRedoPath) deps
+        mapM_ (storeIfChangeDep key) canonicalizedDeps
+        -- For each dep that is a source file (not a redo target), initialize
+        -- its source database so redo recognizes it as a known source.
+        mapM_ initializeSourceIfNeeded canonicalizedDeps
+        -- Stamp the target with current mtime
+        stamp <- stampTarget target
+        storeStamp key stamp
+        -- Mark as built in the session cache
+        markBuilt tempKey
+        return ExitSuccess
   where
     canonicalize path dep = do cpath <- canonicalizePath' $ path </> unTarget dep
                                return $ Target cpath

--- a/test/370-done/all.do
+++ b/test/370-done/all.do
@@ -1,1 +1,1 @@
-redo test-basic test-deps-tracked test-rebuild-on-dep-change test-no-target-fails test-inside-do
+redo test-basic test-deps-tracked test-rebuild-on-dep-change test-no-target-fails test-inside-do test-no-unnecessary-rebuild

--- a/test/370-done/clean.do
+++ b/test/370-done/clean.do
@@ -1,1 +1,1 @@
-rm -f source.txt target.txt target2.txt depfile.txt wrapper.txt
+rm -f source.txt target.txt target2.txt depfile.txt wrapper.txt final.txt

--- a/test/370-done/final.txt.do
+++ b/test/370-done/final.txt.do
@@ -1,0 +1,2 @@
+redo-ifchange target.txt
+echo "final built from target" > "$3"

--- a/test/370-done/test-no-unnecessary-rebuild.do
+++ b/test/370-done/test-no-unnecessary-rebuild.do
@@ -1,0 +1,34 @@
+# Test: After redo-done, a dependent target should NOT be rebuilt
+# if the redo-done target hasn't actually changed.
+#
+# This tests the scenario where:
+# 1. Build everything (redo-done target + redo-ifchange final)
+# 2. Call redo-done again on the UNCHANGED target, then check final
+#    — final should still be up-to-date because target.txt didn't change.
+
+# Setup source
+echo "v1" > source.txt
+
+# Build target.txt externally and register it
+echo "externally built" > target.txt
+redo-done target.txt source.txt
+
+# Build final.txt which depends on target.txt
+redo final.txt
+
+# Flush the session cache to simulate a new session
+../flush-cache
+
+# Call redo-done again on the UNCHANGED target.txt
+# (simulates an external build tool that found nothing to rebuild)
+redo-done target.txt source.txt
+
+# final.txt should still be up to date since target.txt didn't change
+redo-ifchange final.txt
+CONTENT="$(cat final.txt)"
+if [ "$CONTENT" != "final built from target" ]; then
+    echo "FAIL: final.txt was unnecessarily rebuilt after unchanged redo-done! Content: $CONTENT" >&2
+    exit 1
+fi
+
+echo "PASS: test-no-unnecessary-rebuild" >&2


### PR DESCRIPTION
Two fixes for `redo-done` behavior, plus a CI update:

### Bug fix: markClean vs markBuilt
When `redo-done` is called on a target whose stamp hasn't changed, it now marks the target as `clean` (verified up-to-date) instead of `built` (newly rebuilt). The `upToDate` logic treats these differently at recursion depth > 0: `built` signals that parents need rebuilding, while `clean` means the target was verified unchanged. Using `markBuilt` unconditionally caused parent targets to unnecessarily rebuild even when the `redo-done` target didn't actually change.

### Performance: early-exit optimization
When `redo-done` is called for a target whose stamp is unchanged and whose `.do` file matches the cached entry, skip the expensive DB refresh (`removeDatabase` + `createDatabase` + store all deps). This makes repeated `redo-done` calls instant on no-op rebuilds — critical when a build system calls `redo-done` for hundreds of precompiled objects.