### PR TITLE
Bump version to v0.2.2

### DIFF
--- a/src/Version.hs
+++ b/src/Version.hs
@@ -7,7 +7,7 @@ import BuildInfo (gitCommitHash, buildTimestamp)
 
 -- Version string with platform, commit, and build time
 versionString :: String
-versionString = "redo 0.1 (" ++ System.Info.os ++ "-" ++ System.Info.arch ++ ")\n" ++
+versionString = "redo 0.2.2 (" ++ System.Info.os ++ "-" ++ System.Info.arch ++ ")\n" ++
                 "https://github.com/dinkelk/redo\n" ++
                 "commit: " ++ $(gitCommitHash) ++ "\n" ++
                 "built: " ++ $(buildTimestamp)


### PR DESCRIPTION
Updates the version string reported by `redo --version` from 0.1 to 0.2.2.