### PR TITLE
Add diagnostic warning when source database is overwritten

### DIFF
--- a/src/Database.hs
+++ b/src/Database.hs
@@ -8,6 +8,7 @@ module Database (clearRedoTempDirectory, initializeTargetDatabase, hasAlwaysDep,
                  getStdoutFile, getTempFile, markBuilt, isBuilt, markErrored, isErrored) where
 
 import Control.Exception (catch, SomeException(..))
+import Control.Monad (when)
 import qualified Data.ByteString.Char8 as BS
 import Crypto.Hash (hashWith, MD5(..), Digest)
 import qualified Data.ByteArray
@@ -377,7 +378,16 @@ createRedoTempDirectory = do
 -- dependencies hanging around if we are rebuilding a file.
 initializeTargetDatabase :: Key -> DoFile -> IO ()
 initializeTargetDatabase key doFile = withDatabaseLock key func
-  where func = do refreshDatabase key
+  where func = do -- Diagnostic: warn if we're about to overwrite a source-marked
+                  -- database. This should never happen during normal builds — it
+                  -- means a file that redo knows is a source is being treated as
+                  -- a build target. Logging this will help diagnose the root cause
+                  -- of "No rule to build" errors for source files.
+                  wasSource <- doesEntryExist =<< getSourceEntry key
+                  when wasSource $ putWarningStrLn $
+                    "Warning: initializeTargetDatabase is overwriting a source-marked database " ++
+                    "(do file: " ++ unDoFile doFile ++ "). This may corrupt redo state."
+                  refreshDatabase key
                   -- Write out .do script as dependency:
                   storeIfChangeDep' key (Target $ unDoFile doFile)
                   -- Cache the do file:


### PR DESCRIPTION
## Summary
- Adds a warning in `initializeTargetDatabase` when it's about to overwrite a database that has a source marker (`y` entry).
- This should never happen during normal builds. If it fires, it means a source file is being treated as a build target — the exact corruption that causes permanent "No rule to build" errors.
- The warning prints the `.do` file path, which will identify exactly which build rule is causing the corruption.
- Zero performance cost (one directory existence check inside an already-locked function).

## Context
Users have reported intermittent "No rule to build" errors for source files after branch switches. We've narrowed the corruption to source files losing their source marker in the redo database, but haven't identified the exact trigger for always-existing files. This diagnostic will fire the moment the corruption happens, revealing the code path responsible.

## Test plan
- [x] Full existing test suite passes
- [x] Warning correctly fires in the `newsource` corner case test (which deliberately converts source → target)
- [x] No false positives in any other test

🤖 Generated with [Claude Code](https://claude.com/claude-code)