### PR TITLE
Make source database operations crash-safe and skip unnecessary refreshes

### DIFF
--- a/src/Build.hs
+++ b/src/Build.hs
@@ -120,8 +120,21 @@ redoIfChange = buildTargets redoIfChange'
       runFromDo <- isRunFromDoFile
       case (source, runFromDo) of
         (True, False) -> targetSourceWarning target
-        (True, True) -> do initializeSourceDatabase key target
-                           return ExitSuccess
+        -- Source file encountered from within a .do file. We need to ensure
+        -- the database is marked as source with a current stamp. However,
+        -- if the stamp hasn't changed since last time, we can skip the
+        -- expensive initializeSourceDatabase call (which deletes and recreates
+        -- the entire database directory). This is important because that
+        -- delete-recreate cycle opens a corruption window: if the process is
+        -- killed (e.g. Ctrl+C -> SIGKILL) between the delete and the
+        -- markSource write, the database is left without a source marker.
+        (True, True) -> do
+          currentStamp <- safeStampTarget target
+          cachedStamp <- getStamp key
+          if currentStamp == cachedStamp
+            then return ExitSuccess
+            else do initializeSourceDatabase key target
+                    return ExitSuccess
         (False, _) -> do
           currentStamp <- safeStampTarget target
           modified <- isTargetModified key currentStamp

--- a/test/375-default-do-source/all.do
+++ b/test/375-default-do-source/all.do
@@ -1,0 +1,2 @@
+redo clean
+sh run_tests.sh

--- a/test/375-default-do-source/clean.do
+++ b/test/375-default-do-source/clean.do
@@ -1,0 +1,1 @@
+rm -rf build src *.log

--- a/test/375-default-do-source/default.do
+++ b/test/375-default-do-source/default.do
@@ -1,0 +1,25 @@
+# Catch-all default.do that mimics a typical project structure:
+# NOTE: no shebang — redo adds "sh -e" automatically, so errors propagate.
+# - Handles targets in build/ directory by depending on corresponding source
+# - Handles "clean" and "all" redo targets
+# - Errors on anything else (source files should never reach here)
+
+case "$1" in
+    build/*)
+        # Build targets: depend on the corresponding source file
+        BASENAME=$(basename "$1")
+        redo-ifchange "src/$BASENAME"
+        echo "built from: $(cat "src/$BASENAME")" > "$3"
+        ;;
+    clean)
+        rm -rf build src *.log
+        ;;
+    all)
+        # Run the test script
+        sh run_tests.sh
+        ;;
+    *)
+        echo "default.do: No rule to build '$1'." >&2
+        exit 1
+        ;;
+esac

--- a/test/375-default-do-source/run_tests.sh
+++ b/test/375-default-do-source/run_tests.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Test for source database refresh optimization.
+#
+# This test directory has a catch-all default.do that handles build/*
+# targets and errors on everything else. The test verifies that
+# initializeSourceDatabase is skipped for unchanged source files
+# (the DB directory is not deleted and recreated unnecessarily),
+# while still refreshing when source files actually change.
+
+set -e
+
+##############################################################################
+# Helpers
+##############################################################################
+get_db_dir() {
+    DB_KEY=$(printf '%s' "$1" | md5sum | awk '{print toupper($1)}')
+    echo "$HOME/.redo/database/$(echo $DB_KEY | cut -c1-3)/$(echo $DB_KEY | cut -c4-9)/$(echo $DB_KEY | cut -c10-21)/$(echo $DB_KEY | cut -c22-)"
+}
+get_stamp_dir() {
+    DB_KEY=$(printf '%s' "$1" | md5sum | awk '{print toupper($1)}')
+    echo "$HOME/.redo/stamps/$(echo $DB_KEY | cut -c1-3)/$(echo $DB_KEY | cut -c4-9)/$(echo $DB_KEY | cut -c10-21)/$(echo $DB_KEY | cut -c22-)"
+}
+
+##############################################################################
+# Setup
+##############################################################################
+mkdir -p src build
+SRC_PATH="$(cd src && pwd)/data.txt"
+BUILD_PATH="$(cd build && pwd)/data.txt"
+rm -rf "$(get_db_dir "$SRC_PATH")" "$(get_stamp_dir "$SRC_PATH")"
+rm -rf "$(get_db_dir "$BUILD_PATH")" "$(get_stamp_dir "$BUILD_PATH")"
+../flush-cache
+
+echo "content v1" > src/data.txt
+
+##############################################################################
+# Initial build — creates source DB with stamp
+##############################################################################
+redo-ifchange build/data.txt
+test "$(cat build/data.txt)" = "built from: content v1" || exit 1
+
+SRC_DB=$(get_db_dir "$SRC_PATH")
+test -d "$SRC_DB/y" || exit 2
+
+# Record the DB directory inode to detect if it gets recreated
+INODE_BEFORE=$(stat -c %i "$SRC_DB" 2>/dev/null || stat -f %i "$SRC_DB" 2>/dev/null)
+
+##############################################################################
+# Rebuild with no changes — DB should NOT be recreated
+##############################################################################
+../flush-cache
+redo-ifchange build/data.txt
+
+test -d "$SRC_DB/y" || exit 3
+
+INODE_AFTER=$(stat -c %i "$SRC_DB" 2>/dev/null || stat -f %i "$SRC_DB" 2>/dev/null)
+if [ "$INODE_BEFORE" != "$INODE_AFTER" ]; then
+    echo "FAIL: source DB was recreated on unchanged rebuild (inode $INODE_BEFORE -> $INODE_AFTER)" >&2
+    exit 4
+fi
+
+##############################################################################
+# Modify source — DB should refresh and target should rebuild
+##############################################################################
+../sleep
+echo "content v2" > src/data.txt
+../flush-cache
+
+redo-ifchange build/data.txt
+test "$(cat build/data.txt)" = "built from: content v2" || exit 5
+test -d "$SRC_DB/y" || exit 6
+
+echo "PASS: source DB skip optimization" >&2
+rm -rf src build


### PR DESCRIPTION
## Summary

Two hardening changes for the redo source database:

**Commit 1: Skip unnecessary source database refresh for unchanged files**

`initializeSourceDatabase` was called unconditionally for every source file on every build, even when nothing changed. This deleted and recreated the database directory each time — unnecessary work that also opened a corruption window. Now we compare the current stamp against the cached stamp and skip the refresh when they match.

**Commit 2: Make initializeSourceDatabase crash-safe by writing source marker first**

When `initializeSourceDatabase` does need to run, it now writes the source marker (`y`) before any destructive operations. Previously it deleted the database first, then wrote the marker — if killed between those steps (e.g. Ctrl+C), the marker was lost. Now the marker is always present after the first write, and stale target entries are cleaned up individually afterward.